### PR TITLE
Change about the reference entry type's name,figures' and tables' format

### DIFF
--- a/njupthesis.bst
+++ b/njupthesis.bst
@@ -520,7 +520,7 @@ FUNCTION {thesis}
     newline$
 }
 
-FUNCTION {masterthesis}
+FUNCTION {mastersthesis}
 {
     thesis
 }

--- a/njupthesis.cls
+++ b/njupthesis.cls
@@ -159,8 +159,8 @@
 \renewcommand\thesection{\arabic{chapter}.\arabic{section}}
 
 \renewcommand{\theequation}{\arabic{chapter}-\arabic{equation}}
-\renewcommand{\thetable}{\arabic{chapter}-\arabic{table}}
-\renewcommand{\thefigure}{\arabic{chapter}-\arabic{figure}}
+\renewcommand{\thetable}{\arabic{chapter}.\arabic{table}}
+\renewcommand{\thefigure}{\arabic{chapter}.\arabic{figure}}
 
 \captionsetup{format=hang}
 \captionsetup{width=\textwidth - 42pt}


### PR DESCRIPTION
Change masterthesis to mastersthesis, which agrees with the standard entry type for bibtex